### PR TITLE
Remove 'interlace' option from webp processing

### DIFF
--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -52,7 +52,6 @@ class Encoder extends AbstractEncoder
             ->getCore()
             ->writeToBuffer('.webp', [
                 'strip'     => true,
-                'interlace' => false,
                 'lossless'  => false,
                 'Q'         => $this->quality,
             ]);


### PR DESCRIPTION
There is no 'interlace' option in writeToBufer method config for webp processing. It causing exception: "webpsave_buffer: no property named `interlace'"
Ref: http://libvips.github.io/libvips/API/current/VipsForeignSave.html#vips-webpsave-buffer