### PR TITLE
Properly set image MIME type when opening from a path

### DIFF
--- a/src/Decoder.php
+++ b/src/Decoder.php
@@ -26,7 +26,10 @@ class Decoder extends AbstractDecoder
             $options['access'] = $accessMode;
         }
 
-        return $this->initFromVips(VipsImage::newFromFile($path, $options));
+        $image = $this->initFromVips(VipsImage::newFromFile($path, $options));
+        $image->setFileInfoFromPath($path);
+
+        return $image;
     }
 
     /**


### PR DESCRIPTION
Without this, format will always be JPEG if no format is explicitly specified. The expected behavior is that the format remains unchanged (PNG becomes PNG etc.).

The built-in GD and Imagick decoders do the same:
* https://github.com/Intervention/image/blob/master/src/Intervention/Image/Gd/Decoder.php#L75
* https://github.com/Intervention/image/blob/master/src/Intervention/Image/Imagick/Decoder.php#L38