### PR TITLE
Implement all Shape variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ $manager = new ImageManager(['driver' => 'vips']);
 
 ### Shapes
 
-- [ ] CircleShape
-- [ ] EllipseShape
-- [ ] LineShape
-- [ ] PolygonShape
-- [ ] RectangleShape
+- [x] CircleShape
+- [x] EllipseShape
+- [x] LineShape
+- [x] PolygonShape
+- [x] RectangleShape
 
 ## Credits
 

--- a/src/Shapes/AbstractShape.php
+++ b/src/Shapes/AbstractShape.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intervention\Image\Vips\Shapes;
+
+use Exception;
+use Intervention\Image\AbstractShape as BaseAbstractShape;
+use Intervention\Image\Image;
+use Intervention\Image\Vips\Color;
+use Jcupitt\Vips\BlendMode;
+
+abstract class AbstractShape extends BaseAbstractShape
+{
+    protected function getSVGAttributes(): array
+    {
+        $attributes['fill'] = 'none';
+        if ($this->background) {
+            $attributes['fill'] = (new Color($this->background))->getRgba();
+        }
+        if ($this->border_width) {
+            $attributes['stroke'] = (new Color($this->border_color))->getRgba();
+            $attributes['stroke-width'] = $this->border_width;
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * @param Image  $image
+     * @param string $shape
+     * @param array  $attributes
+     * @return bool
+     */
+    protected function applyToImageViaSVG(
+        Image $image,
+        $shape,
+        array $attributes = []
+    ): bool {
+        try {
+            /** @var \Jcupitt\Vips\Image $core */
+            $core = $image->getCore();
+
+            $xml_attributes = implode(
+                ' ',
+                array_map(
+                    static function ($key, $value) {
+                        return sprintf(
+                            '%s="%s"',
+                            $key,
+                            htmlspecialchars((string) $value)
+                        );
+                    },
+                    array_keys($attributes),
+                    $attributes
+                )
+            );
+
+            $svg = <<<EOL
+<svg viewBox="0 0 {$image->width()} {$image->height()}" xmlns="http://www.w3.org/2000/svg">
+    <{$shape} {$xml_attributes} />
+</svg>
+EOL;
+            $svgImage = $image->getDriver()->init($svg)->getCore();
+
+            $core = $core->composite([$svgImage], [BlendMode::OVER]);
+
+            $image->setCore($core);
+        } catch (Exception $e) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Shapes/CircleShape.php
+++ b/src/Shapes/CircleShape.php
@@ -4,15 +4,8 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Vips\Shapes;
 
-use Intervention\Image\Image;
-
 class CircleShape extends EllipseShape
 {
-    /**
-     * @var int
-     */
-    public $diameter = 100;
-
     /**
      * Create a new shape instance.
      *
@@ -21,22 +14,6 @@ class CircleShape extends EllipseShape
      */
     public function __construct($diameter = null)
     {
-        $this->width = is_numeric($diameter) ? (int) $diameter : $this->diameter;
-        $this->height = is_numeric($diameter) ? (int) $diameter : $this->diameter;
-        $this->diameter = is_numeric($diameter) ? (int) $diameter : $this->diameter;
-    }
-
-    /**
-     * Draw the shape.
-     *
-     * @param  \Intervention\Image\Image  $image
-     * @param  int  $x
-     * @param  int  $y
-     * @return void
-     * @throws \Intervention\Image\Exception\NotSupportedException
-     */
-    public function applyToImage(Image $image, $x = 0, $y = 0)
-    {
-        throw new NotSupportedException('Circle shape is not supported by VIPS driver.');
+        parent::__construct($diameter, $diameter);
     }
 }

--- a/src/Shapes/EllipseShape.php
+++ b/src/Shapes/EllipseShape.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Intervention\Image\Vips\Shapes;
 
 use Intervention\Image\Image;
-use Intervention\Image\AbstractShape;
-use Intervention\Image\Exception\NotSupportedException;
 
 class EllipseShape extends AbstractShape
 {
@@ -36,14 +34,22 @@ class EllipseShape extends AbstractShape
     /**
      * Draw the shape.
      *
-     * @param  \Intervention\Image\Image  $image
-     * @param  int  $x
-     * @param  int  $y
+     * @param \Intervention\Image\Image $image
+     * @param int                       $x
+     * @param int                       $y
      * @return void
-     * @throws \Intervention\Image\Exception\NotSupportedException
      */
     public function applyToImage(Image $image, $x = 0, $y = 0)
     {
-        throw new NotSupportedException('Ellipse shape is not supported by VIPS driver.');
+        $this->applyToImageViaSVG(
+            $image,
+            'ellipse',
+            [
+                'cx' => $x,
+                'cy' => $y,
+                'rx' => $this->width / 2,
+                'ry' => $this->height / 2,
+            ] + $this->getSVGAttributes()
+        );
     }
 }

--- a/src/Shapes/LineShape.php
+++ b/src/Shapes/LineShape.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Vips\Shapes;
 
 use Intervention\Image\Image;
-use Intervention\Image\AbstractShape;
-use Intervention\Image\Exception\NotSupportedException;
+use Intervention\Image\Vips\Color;
 
 class LineShape extends AbstractShape
 {
@@ -72,10 +71,20 @@ class LineShape extends AbstractShape
      * @param  int  $x
      * @param  int  $y
      * @return void
-     * @throws \Intervention\Image\Exception\NotSupportedException
      */
     public function applyToImage(Image $image, $x = 0, $y = 0)
     {
-        throw new NotSupportedException('Line shape is not supported by VIPS driver.');
+        $this->applyToImageViaSVG(
+            $image,
+            'line',
+            [
+                'x1' => $this->x,
+                'y1' => $this->y,
+                'x2' => $x,
+                'y2' => $y,
+                'stroke-width' => $this->width,
+                'stroke' => (new Color($this->color))->getRgba(),
+            ]
+        );
     }
 }

--- a/src/Shapes/PolygonShape.php
+++ b/src/Shapes/PolygonShape.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Intervention\Image\Vips\Shapes;
 
 use Intervention\Image\Image;
-use Intervention\Image\AbstractShape;
-use Intervention\Image\Exception\NotSupportedException;
 
 class PolygonShape extends AbstractShape
 {
@@ -33,10 +31,15 @@ class PolygonShape extends AbstractShape
      * @param  int  $x
      * @param  int  $y
      * @return void
-     * @throws \Intervention\Image\Exception\NotSupportedException
      */
     public function applyToImage(Image $image, $x = 0, $y = 0)
     {
-        throw new NotSupportedException('Polygon shape is not supported by VIPS driver.');
+        $this->applyToImageViaSVG(
+            $image,
+            'polygon',
+            [
+                'points' => implode(',', $this->points),
+            ] + $this->getSVGAttributes()
+        );
     }
 }

--- a/src/Shapes/RectangleShape.php
+++ b/src/Shapes/RectangleShape.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Intervention\Image\Vips\Shapes;
 
 use Intervention\Image\Image;
-use Intervention\Image\AbstractShape;
-use Intervention\Image\Exception\NotSupportedException;
 
 class RectangleShape extends AbstractShape
 {
@@ -54,10 +52,18 @@ class RectangleShape extends AbstractShape
      * @param  int  $x
      * @param  int  $y
      * @return void
-     * @throws \Intervention\Image\Exception\NotSupportedException
      */
     public function applyToImage(Image $image, $x = 0, $y = 0)
     {
-        throw new NotSupportedException('Rectangle shape is not supported by VIPS driver.');
+        $this->applyToImageViaSVG(
+            $image,
+            'rect',
+            [
+                'x' => $this->x1,
+                'y' => $this->y1,
+                'width' => $this->x2 - $this->x1,
+                'height' => $this->y2 - $this->y1,
+            ] + $this->getSVGAttributes()
+        );
     }
 }


### PR DESCRIPTION
I want to give vips a spin on my project, so I'm doing my best to implement missing functionality.

This PR introduces all shape variants. After previous attempts I have decided to go with creating string with correct SVG representation of shape to be created and use vips to import it and composite over original image.

It gives the same or even nicer results than draw_* results while being way simpler and less "hacky" (creating ellipses or polygons with arbitrary border width would be a nightmare in pure vips).

[OUTDATED - original description]
This PR introduces simple RectangleShape, EllipseShape and CircleShape.

I'm afraid remaining shapes will not be as easy as those because I see no way to control border width in vips. I'm torn between trying to implement them correctly (that would probably be difficult and complex in case of Polygon and Line) or implementing them with only support for single pixel border, ignoring this attribute at all.