### PR TITLE
Add missing abstract implementation for AVIF

### DIFF
--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -58,7 +58,7 @@ class Encoder extends AbstractEncoder
     }
     
      /**
-     * Get the encoded image as GIF string.
+     * Get the encoded image as AVIF string.
      *
      * @return void
      * @throws \Intervention\Image\Exception\NotSupportedException

--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -57,7 +57,7 @@ class Encoder extends AbstractEncoder
             ]);
     }
     
-     /**
+    /**
      * Get the encoded image as AVIF string.
      *
      * @return void

--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -56,6 +56,17 @@ class Encoder extends AbstractEncoder
                 'Q'         => $this->quality,
             ]);
     }
+    
+     /**
+     * Get the encoded image as GIF string.
+     *
+     * @return void
+     * @throws \Intervention\Image\Exception\NotSupportedException
+     */
+    protected function processAvif()
+    {
+        throw new NotSupportedException('AVIF format is not supported by VIPS driver.');
+    }
 
     /**
      * Get the encoded image as GIF string.

--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -56,7 +56,7 @@ class Encoder extends AbstractEncoder
                 'Q'         => $this->quality,
             ]);
     }
-    
+
     /**
      * Get the encoded image as AVIF string.
      *


### PR DESCRIPTION
broken with latest intervention/image version: 2.6

see: https://github.com/Intervention/image/blame/2.6.0/src/Intervention/Image/AbstractEncoder.php

fixes #18 