### PR TITLE
Add support for avif

### DIFF
--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -60,9 +60,7 @@ class Encoder extends AbstractEncoder
     /**
      * Get the encoded image as AVIF string.
      *
-     * @return void
-     *
-     * @throws \Intervention\Image\Exception\NotSupportedException
+     * @return string
      */
     protected function processAvif()
     {

--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -66,7 +66,12 @@ class Encoder extends AbstractEncoder
      */
     protected function processAvif()
     {
-        throw new NotSupportedException('AVIF format is not supported by VIPS driver.');
+        return $this->image
+            ->getCore()
+            ->writeToBuffer('.avif', [
+                'lossless'  => false,
+                'Q'         => $this->quality,
+            ]);
     }
 
     /**


### PR DESCRIPTION
Avif is supported in libvips since v8.9.0, so this adds support for it.
Tested on Debian 11, with default libvips packages.