### PR TITLE
AVIF Encoding Fix

### DIFF
--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -66,9 +66,10 @@ class Encoder extends AbstractEncoder
     {
         return $this->image
             ->getCore()
-            ->writeToBuffer('.avif', [
+            ->writeToBuffer('.heif', [
                 'lossless'  => false,
-                'Q'         => $this->quality,
+                'Q' => $this->quality,
+                'compression' => 'av1',
             ]);
     }
 


### PR DESCRIPTION
Currently AVIF compression is broken.

An exception is thrown:

![20230818-1119](https://github.com/osiemsiedem/intervention-image-vips-driver/assets/10062339/45d40688-e326-404e-9f83-c13070c1dcd6)

I opened issue https://github.com/libvips/php-vips/issues/197 to fix the underlying problem however the [fix](https://github.com/libvips/php-vips/pull/207) shows no signs to making it to a release anytime soon.

This PR adds a workaround to make it work now, and I believe it will continue to work once the fix is merged.